### PR TITLE
Add reproducible STA141C scripts

### DIFF
--- a/STA141C - Data Science III/README.md
+++ b/STA141C - Data Science III/README.md
@@ -1,3 +1,28 @@
 # STA141C - Data Science III
 
-This project predicts flight delays using classification models trained on `airlines_delay.csv`. Execute `code.ipynb` to build the models and consult `report.pdf` for the final write-up.
+This project predicts flight delays using several classification models trained on `airlines_delay.csv`.
+The original work was developed in `code.ipynb` and summarized in `report.pdf`.
+
+## Scripts
+Python scripts in the `scripts` directory reproduce the main analyses:
+
+- `eda.py` – generates exploratory plots and saves them as PNG files.
+- `log_reg_ascent.py` – logistic regression using gradient ascent.
+- `log_reg_descent.py` – logistic regression using gradient descent.
+- `naive_bayes.py` – custom Naive Bayes classifier.
+- `knn.py` – k-nearest neighbors classifier.
+
+Each script loads and preprocesses the data, trains the model using 10 different train/test splits and reports the average accuracy and runtime.
+
+## Usage
+Run a script with Python from this directory. For example:
+
+```bash
+python -m scripts.eda
+python -m scripts.log_reg_ascent
+python -m scripts.log_reg_descent
+python -m scripts.naive_bayes
+python -m scripts.knn
+```
+
+Plots and metrics will be printed or saved in the working directory.

--- a/STA141C - Data Science III/scripts/eda.py
+++ b/STA141C - Data Science III/scripts/eda.py
@@ -1,0 +1,50 @@
+import matplotlib.pyplot as plt
+import seaborn as sns
+from .utils import load_data
+
+
+def main():
+    _, _, df = load_data(sample=10000, standardize=False)
+
+    flights_per_airline = df.groupby('Airline').agg({'Class': 'count'})
+    delays_by_airline = df.groupby('Airline').agg({'Class': 'sum'})
+    flights_per_airline['delays'] = delays_by_airline['Class']
+    flights_per_airline['%_delays'] = flights_per_airline['delays'] / flights_per_airline['Class']
+
+    plt.figure(figsize=(10,7))
+    sns.countplot(y='Airline', hue='Class', data=df)
+    plt.xlabel('Number of Flights')
+    plt.title('Number of Flights On Time and Delayed by Airline')
+    plt.legend(labels=['Delayed', 'On-time'])
+    plt.tight_layout()
+    plt.savefig('flights_by_airline.png')
+
+    plt.figure(figsize=(8,6))
+    sns.barplot(y='Airline', x='%_delays', data=flights_per_airline, orient='h', color='C0')
+    plt.xlabel('Percent of Flights Delayed')
+    plt.title('Percent of Delays by Airline')
+    plt.tight_layout()
+    plt.savefig('percent_delays_airline.png')
+
+    delayed = df[df['Class'] == 1]
+    plt.figure(figsize=(8,5))
+    plt.hist([df['Length'], delayed['Length']], label=['All', 'Delayed'], density=True)
+    plt.xlabel('Length of Flight')
+    plt.title('Normalized Histogram of Length of Flight')
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig('length_hist.png')
+
+    plt.figure(figsize=(8,5))
+    plt.hist([df['DayOfWeek'], delayed['DayOfWeek']], label=['All', 'Delayed'], density=True)
+    plt.xlabel('Day of Week')
+    plt.title('Normalized Histogram of Day of Week')
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig('day_hist.png')
+
+    print('EDA plots saved as PNG files.')
+
+
+if __name__ == "__main__":
+    main()

--- a/STA141C - Data Science III/scripts/knn.py
+++ b/STA141C - Data Science III/scripts/knn.py
@@ -1,0 +1,52 @@
+import numpy as np
+import time
+from sklearn.model_selection import train_test_split
+from joblib import Parallel, delayed
+import multiprocessing
+from .utils import load_data
+
+
+def euclidean(row1, row2):
+    return np.sqrt(((row1 - row2) ** 2).sum())
+
+
+def get_neighbors(train, test_row, num_neighbors):
+    distances = []
+    for idx, row in enumerate(train):
+        dist = euclidean(test_row, row)
+        distances.append((dist, idx))
+    distances.sort(key=lambda x: x[0])
+    return [idx for _, idx in distances[:num_neighbors]]
+
+
+def predict_classification(X_train, y_train, test_row, num_neighbors):
+    neighbor_idx = get_neighbors(X_train, test_row, num_neighbors)
+    output_values = y_train[neighbor_idx]
+    return np.bincount(output_values).argmax()
+
+
+def accuracy_metric(y_true, y_pred):
+    return (y_true == y_pred).mean()
+
+
+def main():
+    X, y, _ = load_data(standardize=True)
+    accuracies = []
+    start = time.time()
+    for i in range(10):
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=0.2, random_state=i
+        )
+        inputs = range(len(X_test))
+        num_cores = multiprocessing.cpu_count()
+        def runner(t):
+            return predict_classification(X_train, y_train, X_test[t], 25)
+        preds = Parallel(n_jobs=num_cores)(delayed(runner)(t) for t in inputs)
+        accuracies.append(accuracy_metric(y_test, np.array(preds)))
+    end = time.time()
+    print(f"Average accuracy: {np.mean(accuracies):.3f}")
+    print(f"Training time: {end - start:.2f} seconds")
+
+
+if __name__ == "__main__":
+    main()

--- a/STA141C - Data Science III/scripts/log_reg_ascent.py
+++ b/STA141C - Data Science III/scripts/log_reg_ascent.py
@@ -1,0 +1,59 @@
+import numpy as np
+import time
+from sklearn.model_selection import train_test_split
+from .utils import load_data
+
+class LogRegGradAscent:
+    """Logistic regression using gradient ascent as defined in the notebook."""
+    def __init__(self, lr=0.01, num_iterations=100):
+        self.lr = lr
+        self.num_iterations = num_iterations
+        self.eps = 1e-10
+        self.weights = None
+        self.lls = []
+
+    def _sigmoid(self, z):
+        return 1 / (1 + np.exp(-z))
+
+    def _log_likelihood(self, y, pred):
+        pred = np.clip(pred, self.eps, 1 - self.eps)
+        ll = y * np.log(pred) + (1 - y) * np.log(1 - pred)
+        return ll.mean()
+
+    def fit(self, X, y):
+        self.weights = np.zeros(X.shape[1])
+        for _ in range(self.num_iterations):
+            z = X @ self.weights
+            pred = self._sigmoid(z)
+            grad = np.mean((y - pred)[:, None] * X, axis=0)
+            self.weights += self.lr * grad
+            self.lls.append(self._log_likelihood(y, pred))
+
+    def predict(self, X, threshold=0.5):
+        prob = self._sigmoid(X @ self.weights)
+        return (prob > threshold).astype(int)
+
+
+def accuracy(y_true, y_pred):
+    return (y_true == y_pred).mean()
+
+
+def main():
+    X, y, _ = load_data(standardize=True)
+    accuracies = []
+    start = time.time()
+    for i in range(10):
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=0.2, random_state=i
+        )
+        model = LogRegGradAscent()
+        model.fit(X_train, y_train)
+        pred = model.predict(X_test)
+        accuracies.append(accuracy(y_test, pred))
+    end = time.time()
+    print(f"Average accuracy: {np.mean(accuracies):.3f}")
+    print(f"Training time: {end - start:.2f} seconds")
+
+
+if __name__ == "__main__":
+    main()

--- a/STA141C - Data Science III/scripts/log_reg_descent.py
+++ b/STA141C - Data Science III/scripts/log_reg_descent.py
@@ -1,0 +1,52 @@
+import numpy as np
+import math
+import time
+from sklearn.model_selection import train_test_split
+from .utils import load_data
+
+
+def generateX(X):
+    return np.c_[np.ones((len(X), 1)), X]
+
+def get_initial_vec(X):
+    return np.random.randn(X.shape[1] + 1, 1)
+
+def sigmoid_function(X):
+    return 1 / (1 + np.exp(-X))
+
+def Logistic_Fit(X, y, learningrate, iterations):
+    y_new = y.reshape(-1, 1)
+    X_aug = generateX(X)
+    theta = get_initial_vec(X)
+    m = len(X)
+    for _ in range(iterations):
+        gradients = 2 / m * X_aug.T.dot(sigmoid_function(X_aug.dot(theta)) - y_new)
+        theta = theta - learningrate * gradients
+    return theta
+
+def predict(theta, X):
+    X_aug = generateX(X)
+    logits = sigmoid_function(X_aug.dot(theta))
+    return (logits >= 0.5).astype(int).ravel()
+
+def accuracy_metric(y_true, y_pred):
+    return (y_true == y_pred).mean()
+
+def main():
+    X, y, _ = load_data(standardize=False)
+    accuracies = []
+    start = time.time()
+    for i in range(10):
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=0.2, random_state=i
+        )
+        theta = Logistic_Fit(X_train, y_train, 0.1, 100)
+        pred = predict(theta, X_test)
+        accuracies.append(accuracy_metric(y_test, pred))
+    end = time.time()
+    print(f"Average accuracy: {np.mean(accuracies):.3f}")
+    print(f"Training time: {end - start:.2f} seconds")
+
+
+if __name__ == "__main__":
+    main()

--- a/STA141C - Data Science III/scripts/naive_bayes.py
+++ b/STA141C - Data Science III/scripts/naive_bayes.py
@@ -1,0 +1,56 @@
+import numpy as np
+import time
+from multiprocessing.pool import ThreadPool
+from sklearn.model_selection import train_test_split
+from .utils import load_data
+
+
+def max_class(x, prior_list, mean_list, variance_list):
+    likelihoods = []
+    for idx in range(2):
+        num = np.exp((-1/2) * ((x - mean_list[idx]) ** 2) / (2 * variance_list[idx]))
+        den = np.sqrt(2 * np.pi * variance_list[idx])
+        likelihoods.append(num / den)
+    post = [np.log(prior_list[0]) + np.sum(np.log(likelihoods[0])),
+            np.log(prior_list[1]) + np.sum(np.log(likelihoods[1]))]
+    return np.argmax(post)
+
+
+def Parallel_NB(X_train, X_test, y_train):
+    n = len(X_train)
+    m = X_train.shape[1]
+    prior_list = np.zeros(2)
+    mean_list = np.zeros((2, m))
+    variance_list = np.zeros((2, m))
+    for idx in range(2):
+        sub = X_train[y_train == idx]
+        prior_list[idx] = len(sub) / n
+        mean_list[idx, :] = sub.mean(axis=0)
+        variance_list[idx, :] = sub.var(axis=0)
+    Xis = X_test
+    pool = ThreadPool(5)
+    preds = [pool.apply(max_class, args=(Xi, prior_list, mean_list, variance_list)) for Xi in Xis]
+    return np.array(preds)
+
+
+def accuracy(y_true, y_pred):
+    return (y_true == y_pred).mean()
+
+
+def main():
+    X, y, _ = load_data(standardize=False)
+    accuracies = []
+    start = time.time()
+    for i in range(10):
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=0.2, random_state=i, shuffle=True
+        )
+        preds = Parallel_NB(X_train, X_test, y_train)
+        accuracies.append(accuracy(y_test, preds))
+    end = time.time()
+    print(f"Average accuracy: {np.mean(accuracies):.3f}")
+    print(f"Training time: {end - start:.2f} seconds")
+
+
+if __name__ == "__main__":
+    main()

--- a/STA141C - Data Science III/scripts/utils.py
+++ b/STA141C - Data Science III/scripts/utils.py
@@ -1,0 +1,23 @@
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+
+def load_data(sample=10000, standardize=False):
+    """Load airlines_delay.csv and optionally standardize predictors.
+    Returns X, y arrays and the sampled dataframe."""
+    df = pd.read_csv('airlines_delay.csv')
+
+    # label encode categorical columns
+    df['NumAirline'] = df['Airline'].astype('category').cat.codes
+    df['NumAirportFrom'] = df['AirportFrom'].astype('category').cat.codes
+    df['NumAirportTo'] = df['AirportTo'].astype('category').cat.codes
+
+    df = df.sample(n=sample, random_state=0)
+    X = df[['Length', 'NumAirline', 'NumAirportFrom', 'NumAirportTo', 'DayOfWeek']]
+    y = df['Class']
+
+    if standardize:
+        scaler = StandardScaler()
+        X = scaler.fit_transform(X)
+    else:
+        X = X.values
+    return X, y.values, df


### PR DESCRIPTION
## Summary
- add python utility to load data
- create scripts for EDA, logistic regression, naive Bayes and kNN
- update STA141C README with usage instructions

## Testing
- `python -m scripts.log_reg_ascent` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687f111d665c83339650b1f13419c44f